### PR TITLE
Make master compatible with shop master phpunit

### DIFF
--- a/src/Service/Integration/IntegrationScriptBuilder.php
+++ b/src/Service/Integration/IntegrationScriptBuilder.php
@@ -4,11 +4,11 @@ namespace OxidProfessionalServices\Usercentrics\Service\Integration;
 
 class IntegrationScriptBuilder implements IntegrationScriptBuilderInterface
 {
-    /** @var IntegrationVersionFactory */
+    /** @var IntegrationVersionFactoryInterface */
     private $integrationVersionFactory;
 
     public function __construct(
-        IntegrationVersionFactory $integrationVersionFactory
+        IntegrationVersionFactoryInterface $integrationVersionFactory
     ) {
         $this->integrationVersionFactory = $integrationVersionFactory;
     }

--- a/tests/Integration/Service/RendererTest.php
+++ b/tests/Integration/Service/RendererTest.php
@@ -27,7 +27,10 @@ class RendererTest extends UnitTestCase
         $sut = $this->createRenderer($file);
         $rendered = $sut->formFilesOutput([0 => ["http://shop.de/out/theme/js/test.js"]], "");
 
-        $this->assertContains('<script type="text/javascript" src="http://shop.de/out/theme/js/test.js"></script>', $rendered);
+        $this->assertStringContainsString(
+            '<script type="text/javascript" src="http://shop.de/out/theme/js/test.js"></script>',
+            $rendered
+        );
     }
 
     public function testServiceNamedScript(): void
@@ -36,7 +39,7 @@ class RendererTest extends UnitTestCase
         $sut = $this->createRenderer($file);
         $rendered = $sut->formFilesOutput([0 => ["https://shop.de/out/theme/js/test1.js"]], "");
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<script type="text/plain" data-usercentrics="name1" src="https://shop.de/out/theme/js/test1.js"></script>',
             $rendered
         );
@@ -63,7 +66,7 @@ alert('Service2')
 </script>
 HTML;
         $expectedResult = str_replace("\n", '', $expectedResult);
-        $this->assertContains($expectedResult, $rendered);
+        $this->assertStringContainsString($expectedResult, $rendered);
     }
 
     public function testNoSnippet(): void

--- a/tests/Integration/Service/YamlStorageTest.php
+++ b/tests/Integration/Service/YamlStorageTest.php
@@ -52,7 +52,7 @@ class YamlStorageTest extends UnitTestCase
             'ConfigReadTest.yaml'
         );
 
-        $this->assertFileNotExists($path . DIRECTORY_SEPARATOR . $file);
+        $this->assertFileDoesNotExist($path . DIRECTORY_SEPARATOR . $file);
 
         $this->assertEquals([], $sut->getData());
     }


### PR DESCRIPTION
## Issue
Wasn't able to run phpunit within testinglibrary after composer checkout

## Description
While checking the ci to run usercentrics on master discovered some problems with linking within constructor and also some errors and warnings because of phpunit 9 
